### PR TITLE
Support services count in dashboard time series

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -644,7 +644,7 @@ const DashboardPage: React.FC = () => {
                                 <RechartsTooltip
                                   formatter={(value: number, name: string) => [
                                     value,
-                                    'Termine'
+                                    name === 'count' ? 'Termine' : 'Services'
                                   ]}
                                   labelFormatter={(label: string) => {
                                     return new Date(label).toLocaleDateString('de-DE', {
@@ -658,6 +658,14 @@ const DashboardPage: React.FC = () => {
                                   type="monotone"
                                   dataKey="count"
                                   stroke="#1976D2"
+                                  strokeWidth={2}
+                                  dot={{ r: 3 }}
+                                  activeDot={{ r: 5 }}
+                                />
+                                <Line
+                                  type="monotone"
+                                  dataKey="services"
+                                  stroke="#FF9800"
                                   strokeWidth={2}
                                   dot={{ r: 3 }}
                                   activeDot={{ r: 5 }}

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -24,6 +24,7 @@ export interface DashboardData {
   appointment_time_series: Array<{
     date: string;
     count: number;
+    services?: number;
   }>;
   // Note: top_services and busy_times are no longer in this payload structure
   // Note: revenue is replaced by costs in summary


### PR DESCRIPTION
## Summary
- extend dashboard data interface to expose `services` in time series
- display both appointment and service counts in dashboard chart

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*